### PR TITLE
chart - switch to dots per reading 

### DIFF
--- a/report.py
+++ b/report.py
@@ -211,7 +211,7 @@ class DayReadings:
         y_values = np.ma.array(yaxis)
         y_values_masked = np.ma.masked_where(y_values <= 0 , y_values)
 
-        ax.plot(xaxis, y_values_masked)
+        ax.plot(xaxis, y_values_masked, 'o', markersize=1)
         ax.margins(x=0, y=0)
         ax.axes.set_ylim(bottom=_MINLEVEL, top=_MAXLEVEL)
         ax.xaxis.set_ticks(np.arange(0, len(xaxis), 48))

--- a/report.py
+++ b/report.py
@@ -204,16 +204,14 @@ class DayReadings:
 
         ax.axhspan(_MINLEVEL, _LOWLEVEL, alpha=0.2, color='red')
         ax.axhspan(_HIGHLEVEL, _MAXLEVEL, alpha=0.2, color='yellow')
-        ax.plot(xaxis, yaxis)
         ax.hlines(_LOWLEVEL, 0, len(xaxis), colors='k', linestyles='solid', label='low')
+        ax.hlines(_HIGHLEVEL, 0, len(xaxis), colors='k', linestyles='solid', label='high')
 
         # leave out missed (zero) readings
         y_values = np.ma.array(yaxis)
         y_values_masked = np.ma.masked_where(y_values <= 0 , y_values)
 
         ax.plot(xaxis, y_values_masked)
-        ax.hlines(_LOWLEVEL, 0, len(xaxis), colors='k', linestyles='solid', label='low')
-        ax.hlines(_HIGHLEVEL, 0, len(xaxis), colors='k', linestyles='solid', label='high')
         ax.margins(x=0, y=0)
         ax.axes.set_ylim(bottom=_MINLEVEL, top=_MAXLEVEL)
         ax.xaxis.set_ticks(np.arange(0, len(xaxis), 48))


### PR DESCRIPTION
Personally I found dots easier to read, although the change you just made fixed the main issue (not being able to distinguish missed vs actual readings on the line). Maybe I'm also just used to how xdrip renders it. I prefer the dots but up to you 🤷

The data points and high level line were also being rendered twice, which I assume was not intentional? The data points one was noticeable when I switched 1/2 of them to dots. I put the hline calls before the dots assuming the last one renders over the other.

The dots is debatable/opinionated, and I could misunderstanding the double rendering, so feel free to close this or just cherry-pick one or the other.

Before (double rendering):
![Screen Shot 2020-12-17 at 2 43 50 PM](https://user-images.githubusercontent.com/89246/102554124-fe33e880-4078-11eb-9ca7-65f7410c3b32.png)

Removing the double rendering:
![Screen Shot 2020-12-17 at 2 44 27 PM](https://user-images.githubusercontent.com/89246/102554144-0724ba00-4079-11eb-94cf-4180cf8dfa41.png)

Switching to dots:
![Screen Shot 2020-12-17 at 3 02 58 PM](https://user-images.githubusercontent.com/89246/102554638-0a6c7580-407a-11eb-877d-04f6fb4bee7d.png)

(I also know nothing about this charting library and have never actually used python, so all feedback is welcome :)